### PR TITLE
Test assertion order fix

### DIFF
--- a/tests/class-launchkey-wp-saml2-service-test.php
+++ b/tests/class-launchkey-wp-saml2-service-test.php
@@ -291,13 +291,13 @@ class LaunchKey_WP_SAML2_Service_Test extends PHPUnit_Framework_TestCase {
 		);
 		$sql_time = strtotime( $insert_date_string );
 
-		$this->assertGreaterThanOrEqual( $sql_time, $start, sprintf(
+		$this->assertGreaterThanOrEqual( $start, $sql_time, sprintf(
 			"Date string of %s is not on or after recorded start time of %s",
 			$insert_date_string,
 			date( 'Y-m-d H:i:s', $start )
 		) );
 
-		$this->assertLessThanOrEqual( $sql_time, $end, sprintf(
+		$this->assertLessThanOrEqual( $end, $sql_time, sprintf(
 			"Date string of %s is not on or after recorded start time of %s",
 			$insert_date_string,
 			date( 'Y-m-d H:i:s', $end )


### PR DESCRIPTION
There is a time based test that has the expected and actual values reversed. It passes most of the time as it occurs within the same second. This is why it was not noticed until now.